### PR TITLE
increase allowed message size

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,4 +5,4 @@ This module initializes the package with essential metadata. The version attribu
 helps in tracking the current release of the package.
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/exd_api_server.py
+++ b/exd_api_server.py
@@ -21,7 +21,13 @@ def serve():
     By default the server will use https.
     """
     logging.info("Starting server")
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    server = grpc.server(
+        futures.ThreadPoolExecutor(max_workers=10),
+        options=[
+            ("grpc.max_send_message_length", 256 * 1024 * 1024),
+            ("grpc.max_receive_message_length", 16 * 1024 * 1024),
+        ],
+    )
     ods_external_data_pb2_grpc.add_ExternalDataReaderServicer_to_server(ExternalDataReader(), server)
     server.add_insecure_port("[::]:50051")
     server.start()


### PR DESCRIPTION
Allow up to 256MB to be transported from the plugin. This should be O.K. for Excel files.